### PR TITLE
Remove ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.6.3'
-
 gem 'rails', '~> 6.1.3.1'
 gem 'bootstrap-sass'
 gem 'puma', '~> 4.3.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -560,8 +560,5 @@ DEPENDENCIES
   webdrivers
   will_paginate (= 3.1.7)
 
-RUBY VERSION
-   ruby 2.6.3p62
-
 BUNDLED WITH
    1.17.3


### PR DESCRIPTION
## 機能

HerokuにデプロイするためにRubyバージョンを削除（Rails公式が推奨）#62 

## issue

#63